### PR TITLE
Add di example

### DIFF
--- a/example/di_test.py
+++ b/example/di_test.py
@@ -1,0 +1,48 @@
+import di
+import os
+
+
+container = di.Container()
+
+
+class ConfigReader:
+    def get_config(self):
+        pass
+
+
+class EnvironmentConfigReader(ConfigReader):
+    def get_config(self):
+        return {
+            "logging": {"level": os.environ.get("LOGGING_LEVEL", "debug")},
+            "greeting": os.environ.get("GREETING", "Hello world"),
+        }
+
+
+container.bind(di.Dependant(EnvironmentConfigReader), ConfigReader)
+
+
+class Greeter:
+    def greet(self):
+        pass
+
+
+class ConsoleGreeter(Greeter):
+    def __init__(self, config_reader: ConfigReader):
+        self.config = config_reader.get_config()
+
+    def greet(self):
+        print(self.config["greeting"])
+
+
+container.bind(di.Dependant(ConsoleGreeter), Greeter)
+
+provider = container.solve(di.Dependant(Greeter))
+
+
+def di_main():
+    greeter = container.execute_sync(provider)
+    assert isinstance(greeter, ConsoleGreeter)
+
+
+if __name__ == "__main__":
+    di_main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs==1.4.4
 backcall==0.2.0
 black==20.8b1
 click==7.1.2
+di==0.4.7
 decorator==4.4.2
 ipython==7.19.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.4
 backcall==0.2.0
 black==20.8b1
 click==7.1.2
-di==0.4.7
+di==0.4.21
 decorator==4.4.2
 ipython==7.19.0
 ipython-genutils==0.2.0


### PR DESCRIPTION
Hi @RobertoPrevato, I think this is ready now 😄 

I added a sync interface in DI, and some optimizations to handle trivial cases (like this one) without spinning up async executors, etc.

I'm getting the following timings running locally:
- rodi: 5us
- punq: 150us
- di: 27us

Which seems pretty reasonable.
I did some profiling, `di` spends a lot of its time enter scopes (creating an empty dict, creating an `ExitStack` and some other stuff) which is expected. This should be ~ constant in regards to the size of the dependency DAG though.