### PR TITLE
Update di version & usage

### DIFF
--- a/example/di_test.py
+++ b/example/di_test.py
@@ -1,8 +1,9 @@
 import di
+from di.executors import SimpleSyncExecutor
 import os
 
 
-container = di.Container()
+container = di.Container(executor=SimpleSyncExecutor())
 
 
 class ConfigReader:
@@ -37,10 +38,11 @@ class ConsoleGreeter(Greeter):
 container.bind(di.Dependant(ConsoleGreeter), Greeter)
 
 provider = container.solve(di.Dependant(Greeter))
-
+# warmup
+container.execute_sync(provider, validate_scopes=False)
 
 def di_main():
-    greeter = container.execute_sync(provider)
+    greeter = container.execute_sync(provider, validate_scopes=False)
     assert isinstance(greeter, ConsoleGreeter)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.4
 backcall==0.2.0
 black==20.8b1
 click==7.1.2
-di==0.4.21
+di==0.27.9
 decorator==4.4.2
 ipython==7.19.0
 ipython-genutils==0.2.0


### PR DESCRIPTION
The main changes on the `di` side are caching of execution plans.

This is important because `di` will dynamically modify the DAG, e.g. to remove branches that are cached or passed in by value. So, for example, a dependency might be establishing a DB connection -> which depends on loading a config from a file. If the DB connection is cached between executions (this is a fundamental part of di's design), we don't want to load the config from the file for no reason. This requires dynamically modifying the DAG each execution (or at least checking if we can use the cached state).

This completely eliminates unnecessary computation / calling of user functions, but does add some overhead during the first execution at least (hence the addition of warmup run).

I am also using `validate_scopes=False` to put `di` on more even footing w/ the other frameworks (which do not do that validation AFAIK).

I am now getting \~30 µs, which is a pretty solid improvement over the previous benchmarks, despite the added complexity.
It's still not close to rodi (\~5 µs), but the overhead is relatively constant, so as soon as you throw in something like establishing a DB connection (\~ 1ms) it falls within the margin of error (just anecdotal benchmarks, not tested here).