### PR TITLE
Update di example

### DIFF
--- a/example/di_test.py
+++ b/example/di_test.py
@@ -1,8 +1,9 @@
 import di
+from di.container import bind_by_type
 import os
 
 
-container = di.Container(scopes=(None,))
+container = di.Container()
 
 
 class ConfigReader:
@@ -18,7 +19,7 @@ class EnvironmentConfigReader(ConfigReader):
         }
 
 
-container.register_by_type(di.Dependant(EnvironmentConfigReader), ConfigReader)
+container.bind(bind_by_type(di.Dependant(EnvironmentConfigReader), ConfigReader))
 
 
 class Greeter:
@@ -34,8 +35,8 @@ class ConsoleGreeter(Greeter):
         print(self.config["greeting"])
 
 
-container.register_by_type(di.Dependant(ConsoleGreeter), Greeter)
-provider = container.solve(di.Dependant(Greeter))
+container.bind(bind_by_type(di.Dependant(ConsoleGreeter), Greeter))
+provider = container.solve(di.Dependant(Greeter), scopes=(None,))
 executor = di.SyncExecutor()
 
 def di_main():

--- a/example/di_test.py
+++ b/example/di_test.py
@@ -2,7 +2,7 @@ import di
 import os
 
 
-container = di.Container()
+container = di.Container(scopes=(None,))
 
 
 class ConfigReader:
@@ -18,7 +18,7 @@ class EnvironmentConfigReader(ConfigReader):
         }
 
 
-container.bind(di.Dependant(EnvironmentConfigReader), ConfigReader)
+container.register_by_type(di.Dependant(EnvironmentConfigReader), ConfigReader)
 
 
 class Greeter:
@@ -34,13 +34,13 @@ class ConsoleGreeter(Greeter):
         print(self.config["greeting"])
 
 
-container.bind(di.Dependant(ConsoleGreeter), Greeter)
+container.register_by_type(di.Dependant(ConsoleGreeter), Greeter)
 provider = container.solve(di.Dependant(Greeter))
-# warmup
-provider = container.solve(di.Dependant(Greeter))
+executor = di.SyncExecutor()
 
 def di_main():
-    greeter = container.execute_sync(provider)
+    with container.enter_scope(None):
+        greeter = container.execute_sync(provider, executor=executor)
     assert isinstance(greeter, ConsoleGreeter)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.4
 backcall==0.2.0
 black==20.8b1
 click==7.1.2
-di==0.51.0
+di==0.66.1
 decorator==4.4.2
 ipython==7.19.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.4
 backcall==0.2.0
 black==20.8b1
 click==7.1.2
-di==0.30.0
+di==0.51.0
 decorator==4.4.2
 ipython==7.19.0
 ipython-genutils==0.2.0


### PR DESCRIPTION
Timings (on my laptop) with this update:

```
In [1]: from example.di_test import di_main

In [2]: from example.rodi_test import rodi_main

In [3]: %timeit di_main
12.5 ns ± 0.0621 ns per loop (mean ± std. dev. of 7 runs, 100000000 loops each)

In [4]: %timeit rodi_main
13.3 ns ± 0.917 ns per loop (mean ± std. dev. of 7 runs, 100000000 loops each)
```

The main change that enabled this was giving executors control over topological sorting of dependencies, which means that non-concurrent executors (like the one being used in this example) can use a pre-computed topological sort instead of the "online" topological sort (which is needed to exploit maximum concurrency). In practice, this just means using [TopoligcalSorter.static_order()](https://docs.python.org/3/library/graphlib.html#graphlib.TopologicalSorter.static_order) instead of [TopologicalSorter.get_ready()](https://docs.python.org/3/library/graphlib.html#graphlib.TopologicalSorter.get_ready) and [TopologicalSorter.done()](https://docs.python.org/3/library/graphlib.html#graphlib.TopologicalSorter.done)